### PR TITLE
add jib to build docker image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${project.springBootVersion}"
         classpath "io.freefair.gradle:maven-plugin:${project.gradleMavenPluginVersion}"
+        classpath "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:${project.jibVersion}"
     }
 }
 
@@ -35,6 +36,7 @@ apply plugin: "idea"
 
 def currentBranch = "master"
 def currentVersion = "$System.env.casVersion"
+def casServerVersion = project.casVersion
 if (!currentVersion.contains("RC")) {
     def matcher = currentVersion =~ /(\d+\.\d+\.).+/
     if (matcher.find()) {
@@ -80,4 +82,54 @@ bootRun {
 
 dependencies {
     // add extra dependencies here
+}
+
+apply plugin: "com.google.cloud.tools.jib"
+
+jib {
+    from {
+        image = project.baseDockerImage
+    }
+    to {
+        image = "${project.imageorg}/${project.imagerepo}"
+        /**
+         ecr-login: Amazon Elastic Container Registry (ECR)
+         gcr: Google Container Registry (GCR)
+         osxkeychain: Docker Hub
+         */
+        credHelper = "osxkeychain"
+        /**
+         auth {
+         username = "*******"
+         password = "*******"
+         }
+         */
+        tags = ["v" + casServerVersion]
+    }
+    container {
+        creationTime = "USE_CURRENT_TIMESTAMP"
+        entrypoint = ['/docker/entrypoint.sh']
+        ports = ['80', '443', '8080', '8443']
+        labels = [version:casServerVersion, name:project.imagerepo, group:project.group, org:project.imageorg]
+        workingDirectory = '/docker/cas/war'
+    }
+    extraDirectories {
+        paths {
+            path {
+                from = file('src/main/jib')
+            }
+            path {
+                from = file('etc/cas')
+                into = '/etc/cas'
+            }
+            path {
+                from = file("build/libs")
+                into = "/docker/cas/war"
+            }
+        }
+        permissions = [
+                '/docker/entrypoint.sh': '755'
+        ]
+    }
+    allowInsecureRegistries = project.allowInsecureRegistries
 }

--- a/gitattributes
+++ b/gitattributes
@@ -1,0 +1,6 @@
+# Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
+# See https://help.github.com/articles/dealing-with-line-endings/
+*.sh text eol=lf
+gradlew text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,8 @@ gradleMavenPluginVersion=5.3.0
 sourceCompatibility=11
 targetCompatibility=11
 
-
+jibVersion=2.6.0
+imageorg=apereo
+imagerepo=cas-bootadmin-server
+baseDockerImage=adoptopenjdk/openjdk11:alpine-jre
+allowInsecureRegistries=false

--- a/src/main/jib/docker/entrypoint.sh
+++ b/src/main/jib/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+ENTRYPOINT_DEBUG=${ENTRYPOINT_DEBUG:-false}
+JVM_MEM_OPTS=${JVM_MEM_OPTS:--Xms512m -Xmx2048M}
+JVM_EXTRA_OPTS=${JVM_EXTRA_OPTS:--server -noverify -XX:+TieredCompilation -XX:TieredStopAtLevel=1}
+
+if [ $ENTRYPOINT_DEBUG == "true" ]; then
+  echo -e "\nChecking java..."
+  java -version
+
+  if [ -d /etc/cas ] ; then
+    echo -e "\nListing CAS configuration under /etc/cas..."
+    ls -R /etc/cas
+  fi
+
+  echo -e "\nJava args: ${JVM_MEM_OPTS} ${JVM_EXTRA_OPTS}"
+fi
+
+echo -e "\nRunning CAS Boot Admin Server..."
+# shellcheck disable=SC2086
+exec java $JVM_EXTRA_OPTS $JVM_MEM_OPTS -jar casbootadminserver.war "$@"


### PR DESCRIPTION
The `bootBuildImage` isn't working right now (doesn't seem to be adding the casbootadmin.war) . This adds jib to build the image as an alternative. 